### PR TITLE
Fix seed data reminder description length

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ gem 'jwt'
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
+  gem 'hirb'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,7 @@ GEM
     ffi (1.15.5)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    hirb (0.7.3)
     i18n (1.8.11)
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
@@ -237,6 +238,7 @@ DEPENDENCIES
   database_cleaner
   factory_bot_rails
   faker
+  hirb
   jwt
   listen (~> 3.3)
   pg (~> 1.1)

--- a/app/controllers/v1/reminders_controller.rb
+++ b/app/controllers/v1/reminders_controller.rb
@@ -4,7 +4,16 @@ module V1
 
     # GET /reminders
     def index
-      @reminders = current_user.reminders.chronologically_sorted
+      @reminders = current_user.reminders.chronologically_sorted.map do |r|
+        {
+          id: r.id,
+          description: r.description,
+          date: r.datetime.to_date,
+          time: r.datetime.strftime('%H:%M'),
+          city: r.city,
+          location_coordinates: r.location_coordinates
+        }
+      end
       json_response(@reminders)
     end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,8 @@ module WeatherAppCalendarApi
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = "Central Time (US & Canada)"
+    config.active_record.default_timezone = :local
     # config.eager_load_paths << Rails.root.join("extras")
 
     # Only loads a smaller set of middleware suitable for API only apps.

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,7 +2,7 @@ User.create(name: 'Test User', email: 'foo@bar.com', password: 'foobar44A33!')
 # seed 50 records
 50.times do
   reminder = Reminder.create(
-    description: Faker::Lorem.characters(number: 30),
+    description: Faker::Lorem.words(number: rand(2..3)).join(' '),
     datetime: Faker::Time.forward(days: 364),
     city: Faker::Address.city,
     location_coordinates: "#{Faker::Address.latitude}, #{Faker::Address.longitude}",


### PR DESCRIPTION
In this feature branch I did the following:

- edited the Reminders Controller to return reminders in chronological order and return date and time properties in a proper format
- modified timezone of Rails app to UTC - 6